### PR TITLE
docs: remove option references before they are defined

### DIFF
--- a/guide/index.es.html
+++ b/guide/index.es.html
@@ -266,7 +266,7 @@ rana</code></pre>
 </table>
 </div>
 
-<p><strong>Nuestra recomendación:</strong> Si tu comunidad tiene a alguien cómodo con la línea de comandos de Linux, puede manejar la instalación Docker (Opción A o B). Para la Opción C, necesitas a alguien con experiencia en administración de sistemas. La configuración del nodo Lightning es la parte más compleja — considera pedir ayuda a alguien experimentado, o usar una solución nodo-en-caja.</p>
+<p><strong>💡 Nuestra recomendación:</strong> Si tu comunidad tiene a alguien cómodo con la línea de comandos de Linux, puede manejar la instalación con Docker. La compilación nativa requiere experiencia en administración de sistemas. La configuración del nodo Lightning es la parte más compleja — considera pedir ayuda a alguien experimentado, o usar una solución nodo-en-caja.</p>
 
 <hr>
 

--- a/guide/index.html
+++ b/guide/index.html
@@ -269,7 +269,7 @@ rana</code></pre>
 </table>
 </div>
 
-<p><strong>Our recommendation:</strong> If your community has someone comfortable with the Linux command line, they can handle either Docker-based path: Option A (Docker Hub) or Option B (Docker Build). For Option C, you want someone with sysadmin experience. The Lightning node setup is the most complex part — consider having someone experienced help, or using a node-in-a-box solution.</p>
+<p><strong>💡 Our recommendation:</strong> If your community has someone comfortable with the Linux command line, they can handle the Docker installation. Native compilation requires sysadmin experience. The Lightning node setup is the most complex part — consider having someone experienced help, or using a node-in-a-box solution.</p>
 
 <hr>
 

--- a/guide/index.it.html
+++ b/guide/index.it.html
@@ -418,10 +418,10 @@ rana</code></pre>
       </table>
     </div>
 
-    <p><strong>Il nostro consiglio:</strong> Se la tua comunità ha qualcuno a proprio agio con la riga di comando Linux,
-      può gestire l'installazione Docker (Opzione A o B). Per l'Opzione C, serve qualcuno con esperienza di
-      amministrazione di sistema. La configurazione del nodo Lightning è la parte più complessa — considera di farti
-      aiutare da qualcuno esperto, o di usare una soluzione pronta all'uso.</p>
+    <p><strong>💡 Il nostro consiglio:</strong> Se la tua comunità ha qualcuno a proprio agio con la riga di comando Linux,
+      può gestire l'installazione Docker. La compilazione nativa richiede esperienza di amministrazione di sistema. 
+      La configurazione del nodo Lightning è la parte più complessa — considera di farti aiutare da qualcuno esperto, 
+      o di usare una soluzione pronta all'uso.</p>
 
     <hr>
 

--- a/guide/index.pt.html
+++ b/guide/index.pt.html
@@ -263,7 +263,7 @@ rana</code></pre>
 </table>
 </div>
 
-<p><strong>Nossa recomendação:</strong> Se sua comunidade tem alguém confortável com a linha de comando Linux, essa pessoa pode lidar com a instalação Docker (Opção A ou Opção B). Para a Opção C, é necessário alguém com experiência em administração de sistemas. A configuração do nó Lightning é a parte mais complexa — considere pedir ajuda a alguém experiente, ou usar uma solução nó-na-caixa.</p>
+<p><strong>💡 Nossa recomendação:</strong> Se sua comunidade tem alguém confortável com a linha de comando Linux, essa pessoa pode lidar com a instalação Docker. A compilação nativa requer experiência em administração de sistemas. A configuração do nó Lightning é a parte mais complexa — considere pedir ajuda a alguém experiente, ou usar uma solução nó-na-caixa.</p>
 
 <hr>
 


### PR DESCRIPTION
## Problem

The recommendation paragraph in the Node Setup Guide was mentioning "Option A or B" and "Option C" **before** those options were actually introduced. This made the text confusing for readers who haven't seen the options yet.

### Before
> "...can handle the Docker installation (Option A or B). For Option C, you need..."
> 
> [Then the options are defined below]

### After
> "...can handle the Docker installation. Native compilation requires sysadmin experience..."
> 
> [Then the options are defined below]

## Changes

- Removed specific option letter references (A, B, C) from the recommendation paragraph
- Used generic descriptions instead ("Docker installation" vs "native compilation")
- Added 💡 emoji for visual clarity
- Applied fix to all 4 languages: EN, ES, IT, PT

The reader now understands the concept first, then sees the specific options A, B, C defined immediately after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guidance across multiple language versions to clarify Docker and native compilation requirements with improved visual indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->