### PR TITLE
fix: extend nav breakpoint to 1024px to fix tablet layout

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -310,8 +310,8 @@ const i = t(locale);
     color: var(--accent);
   }
 
-  /* Mobile Styles */
-  @media (max-width: 768px) {
+  /* Mobile + Tablet Styles */
+  @media (max-width: 1024px) {
     .nav-desktop {
       display: none;
     }


### PR DESCRIPTION
## Problem

On tablet-sized screens (approximately 769px–1024px wide), the desktop 
navigation bar doesn't have enough horizontal space to display all nav 
items. This causes the logo text and first nav link to appear merged 
with no spacing between them (e.g. "MostroAbout" with no gap).

The root cause is that the hamburger menu only activates at 
max-width: 768px, but the desktop nav becomes too crowded at widths 
up to ~1024px.

## Solution

Extended the responsive breakpoint from 768px to 1024px so the 
hamburger menu activates on all tablet-sized screens. Desktop screens 
wider than 1024px continue showing the full navigation bar with 
proper spacing.

## Change

`src/components/Header.astro`: Changed media query from 
`@media (max-width: 768px)` to `@media (max-width: 1024px)`

## Testing

Tested at the following viewport widths:
- 769px (tablet) ✅ now shows hamburger menu correctly
- 850px (tablet landscape) ✅ hamburger menu
- 1024px (small desktop) ✅ hamburger menu
- 1025px ✅ full desktop nav with proper spacing
- 1280px ✅ full desktop nav with proper spacing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the responsive design breakpoint for the header navigation to enhance layout behavior. Tablet-sized viewports now display the mobile navigation layout instead of the desktop navigation, creating a consistent navigation experience across mobile and tablet devices. Desktop navigation remains available on larger screen sizes for optimal use of available space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->